### PR TITLE
fix(deps): remediate current pnpm advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,9 @@ overrides:
   '@isaacs/brace-expansion@<5.0.1': ^5.0.1
   '@pnpm/npm-conf@<3.0.2': ^3.0.2
   ajv@<6.14.0: 6.14.0
-  axios@<1.15.2: ^1.15.2
+  axios@<1.18.0: ^1.18.0
   brace-expansion@<2.0.3: ^2.0.3
+  brace-expansion@>=3.0.0 <5.0.7: ^5.0.7
   cross-spawn@<7.0.5: ^7.0.5
   '@graphprotocol/graph-cli@0.98.1>decompress@<=4.2.1': npm:@xhmikosr/decompress@^11.1.3
   ejs@<3.1.10: ^3.1.10
@@ -17,8 +18,8 @@ overrides:
   follow-redirects@<1.16.0: ^1.16.0
   form-data@>=4.0.0 <4.0.6: ^4.0.6
   glob@<11.1.0: ^11.1.0
-  immutable@<5.1.5: ^5.1.5
-  js-yaml@<=4.1.1: ^4.2.0
+  immutable@<5.1.8: ^5.1.8
+  js-yaml@<4.3.0: ^4.3.0
   lodash@<4.18.0: ^4.18.0
   lodash.trim@<4.18.0: 4.18.0
   lodash.trimend@<4.18.0: 4.18.0
@@ -532,6 +533,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -606,8 +611,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -647,8 +652,8 @@ packages:
   blob-to-it@2.0.10:
     resolution: {integrity: sha512-I39vO57y+LBEIcAV7fif0sn96fYOYVqrPiOD+53MxQGv4DBgt1/HHZh0BHheWx2hVe24q5LTSXxqeV1Y3Nzkgg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1153,10 +1158,6 @@ packages:
   hashlru@2.3.0:
     resolution: {integrity: sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -1164,6 +1165,10 @@ packages:
   http-call@5.3.0:
     resolution: {integrity: sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==}
     engines: {node: '>=8.0.0'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -1184,8 +1189,8 @@ packages:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
 
-  immutable@5.1.5:
-    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
+  immutable@5.1.9:
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
 
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -1369,8 +1374,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-parse-better-errors@1.0.2:
@@ -2087,7 +2092,7 @@ snapshots:
       globals: 13.20.0
       ignore: 5.2.4
       import-fresh: 3.3.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2100,7 +2105,7 @@ snapshots:
       '@rescript/std': 9.0.0
       graphql: 16.11.0
       graphql-import-node: 0.0.5(graphql@16.11.0)
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@graphprotocol/graph-cli@0.98.1(@types/node@20.11.13)(supports-color@8.1.1)(typescript@4.9.5)(zod@3.25.76)':
     dependencies:
@@ -2120,9 +2125,9 @@ snapshots:
       glob: 11.1.0
       gluegun: 5.2.0(debug@4.4.3(supports-color@8.1.1))
       graphql: 16.11.0
-      immutable: 5.1.5
+      immutable: 5.1.9
       jayson: 4.2.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       kubo-rpc-client: 5.4.1(undici@7.28.0)
       open: 10.2.0
       prettier: 3.6.2
@@ -2703,6 +2708,12 @@ snapshots:
 
   acorn@8.8.2: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -2734,9 +2745,10 @@ snapshots:
 
   apisauce@2.1.6(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
-      axios: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   app-module-path@2.2.0: {}
 
@@ -2770,13 +2782,15 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+  axios@1.18.1(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.6
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   b4a@1.8.1: {}
 
@@ -2796,7 +2810,7 @@ snapshots:
     dependencies:
       browser-readablestream-to-it: 2.0.10
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3084,7 +3098,7 @@ snapshots:
       is-glob: 4.0.3
       is-path-inside: 3.0.3
       js-sdsl: 4.3.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -3256,7 +3270,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-iterator@1.0.2: {}
@@ -3339,6 +3353,7 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   gopd@1.2.0: {}
 
@@ -3370,10 +3385,6 @@ snapshots:
 
   hashlru@2.3.0: {}
 
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
-
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
@@ -3386,6 +3397,13 @@ snapshots:
       is-stream: 2.0.1
       parse-json: 4.0.0
       tunnel-agent: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3403,7 +3421,7 @@ snapshots:
 
   ignore@5.2.4: {}
 
-  immutable@5.1.5: {}
+  immutable@5.1.9: {}
 
   import-fresh@3.3.0:
     dependencies:
@@ -3484,7 +3502,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-retry-allowed@1.2.0: {}
 
@@ -3576,7 +3594,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -3724,7 +3742,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minipass@7.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   axios@<1.15.2: ^1.15.2
   brace-expansion@<2.0.3: ^2.0.3
   cross-spawn@<7.0.5: ^7.0.5
-  decompress@<=4.2.1: npm:@xhmikosr/decompress@^11.1.3
+  '@graphprotocol/graph-cli@0.98.1>decompress@<=4.2.1': npm:@xhmikosr/decompress@^11.1.3
   ejs@<3.1.10: ^3.1.10
   flatted@<3.4.2: ^3.4.2
   follow-redirects@<1.16.0: ^1.16.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ overrides:
   "axios@<1.15.2": "^1.15.2"
   "brace-expansion@<2.0.3": "^2.0.3"
   "cross-spawn@<7.0.5": "^7.0.5"
-  "decompress@<=4.2.1": "npm:@xhmikosr/decompress@^11.1.3"
+  "@graphprotocol/graph-cli@0.98.1>decompress@<=4.2.1": "npm:@xhmikosr/decompress@^11.1.3"
   "ejs@<3.1.10": "^3.1.10"
   "flatted@<3.4.2": "^3.4.2"
   "follow-redirects@<1.16.0": "^1.16.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,15 +2,15 @@ blockExoticSubdeps: true
 engineStrict: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - "axios@1.16.0"
   - "form-data@4.0.6"
 allowBuilds: {}
 overrides:
   "@isaacs/brace-expansion@<5.0.1": "^5.0.1"
   "@pnpm/npm-conf@<3.0.2": "^3.0.2"
   "ajv@<6.14.0": "6.14.0"
-  "axios@<1.15.2": "^1.15.2"
+  "axios@<1.18.0": "^1.18.0"
   "brace-expansion@<2.0.3": "^2.0.3"
+  "brace-expansion@>=3.0.0 <5.0.7": "^5.0.7"
   "cross-spawn@<7.0.5": "^7.0.5"
   "@graphprotocol/graph-cli@0.98.1>decompress@<=4.2.1": "npm:@xhmikosr/decompress@^11.1.3"
   "ejs@<3.1.10": "^3.1.10"
@@ -18,8 +18,8 @@ overrides:
   "follow-redirects@<1.16.0": "^1.16.0"
   "form-data@>=4.0.0 <4.0.6": "^4.0.6"
   "glob@<11.1.0": "^11.1.0"
-  "immutable@<5.1.5": "^5.1.5"
-  "js-yaml@<=4.1.1": "^4.2.0"
+  "immutable@<5.1.8": "^5.1.8"
+  "js-yaml@<4.3.0": "^4.3.0"
   "lodash@<4.18.0": "^4.18.0"
   "lodash.trim@<4.18.0": "4.18.0"
   "lodash.trimend@<4.18.0": "4.18.0"


### PR DESCRIPTION
## Summary

Current pnpm installs now resolve the observed vulnerable `axios`, `brace-expansion`, `immutable`, `js-yaml`, and `decompress` paths to patched releases. The `decompress` replacement is limited to Graph CLI so unrelated consumers retain their existing versions and runtime contracts.

## Validation

- `pnpm install --frozen-lockfile` from a clean dependency state
- `pnpm audit --audit-level moderate` — no known vulnerabilities
- `pnpm run build`
- `pnpm run lint:check`
- Structured commit review — no actionable findings

The repository does not define a test suite; CI skips that step.
